### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "bin": "dist/cli.js",
   "author": "Suchipi <me@suchipi.com>",
   "license": "MIT",
+  "repository": "suchipi/grep-ast",
   "devDependencies": {
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.3.3",


### PR DESCRIPTION
Including the `repository` field will open the GitHub repo in your browser when running `npm docs grep-ast`. It will also help navigate users of repo.now.sh (a tool I made) to redirect https://repo.now.sh/grep-ast to https://github.com/suchipi/grep-ast. Thanks!